### PR TITLE
fix github pages deployment and fix broken links

### DIFF
--- a/CppCoreGuidelines-zh-CN.md
+++ b/CppCoreGuidelines-zh-CN.md
@@ -5640,7 +5640,7 @@ C++11 的初始化式列表规则免除了对许多构造函数的需求。例�
         vector<int> v;
     };
 
-    X x; // 意为 X{{}, {}}; 即空字符串和空 vector
+    X x; // 意为 X{{ "{{" }}}, {}}; 即空字符串和空 vector
 
 需要注意的是，内建类型并不会进行正确的默认构造：
 
@@ -8343,7 +8343,7 @@ B 类别中的数据成员应当为 `private` 或 `const`。这是因为封装�
 
     void use(B*);
 
-    D a[] = {{1, 2}, {3, 4}, {5, 6}};
+    D a[] = {{ "{{" }}1, 2}, {3, 4}, {5, 6}};
     B* p = a;     // 不好: a 退化为 &a[0]，并被转换为 B*
     p[1].x = 7;   // 覆盖了 a[0].y
 
@@ -12523,7 +12523,7 @@ C 风格的强制转换很危险，因为它可以进行任何种类的转换，
     class Shape { /* ... */ };
     class Circle : public Shape { /* ... */ Point c; int r; };
 
-    Circle c {{0, 0}, 42};
+    Circle c {{ "{{" }}0, 0}, 42};
     Shape s {c};    // 仅复制构造了 Circle 中的 Shape 部分
     s = c;          // 仅复制赋值了 Circle 中的 Shape 部分
 
@@ -12531,7 +12531,7 @@ C 风格的强制转换很危险，因为它可以进行任何种类的转换，
     {
         dest = src;
     }
-    Circle c2 {{1, 1}, 43};
+    Circle c2 {{ "{{" }}1, 1}, 43};
     assign(c, c2);   // 噢，传递的并不是整个状态
     assert(c == c2); // 如果提供复制操作，就也得提供比较操作，
                      //   但这里很可能返回 false
@@ -15871,7 +15871,7 @@ lambda 表达式会产生一个带有存储的闭包对象，它通常在运行�
 
     void use()
     {
-        Foo bar {{Thing{1}, Thing{2}, Thing{monkey}}, {"my_file", "r"}, "Here we go!"};
+        Foo bar {{ "{{" }}Thing{1}, Thing{2}, Thing{monkey}}, {"my_file", "r"}, "Here we go!"};
         // ...
     }
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## 起步
 
 指导方针内容见 [CppCoreGuidelines](CppCoreGuidelines-zh-CN.md)。该文档为 [GH 风格 MarkDown 格式](https://github.github.com/gfm/)。我们有意维持文档简单，（英文原版）基本上是 ASCII，以便于进行诸如语言翻译和格式转换之类的自动化后处理。
-编写者们还维护了[一个适于浏览的版本](http://lynnboy.github.io/CppCoreGuidelines-zh-CN/CppCoreGuidelines)。请注意它由人工集成，因而可能略晚于 master 分支的版本。
+编写者们还维护了[一个适于浏览的版本](CppCoreGuidelines-zh-CN)。请注意它由人工集成，因而可能略晚于 master 分支的版本。
 [英文原版](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)。
 
 这些指导方针是持续不断演进的文档，并且没有严格的“发布”节奏。Bjarne Stroustrop 定期评审文档并增加导言部分的版本号。[增加版本号的签入](https://github.com/isocpp/CppCoreGuidelines/releases) 都在 git 中打了标签。

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 >"Within C++ is a smaller, simpler, safer language struggling to get out."
 >-- <cite>Bjarne Stroustrup</cite>
 
-[《C++ 核心指导方针》（The C++ Core Guidelines）](CppCoreGuidelines.md)，与 C++ 语言本身一样，是由 Bjarne Stroustrup 领导的协作项目。
+[《C++ 核心指导方针》（The C++ Core Guidelines）](CppCoreGuidelines-zh-CN.md)，与 C++ 语言本身一样，是由 Bjarne Stroustrup 领导的协作项目。
 该指导方针是许多组织和团体之间耗费了大量人年的探讨和设计的心血成果。它们的设计着眼于普遍的适用性并鼓励广泛采纳，
 但您也可以对其进行随意的复制和修改，以满足您的团体组织自身的需要。
 
 ## 起步
 
-指导方针内容见 [CppCoreGuidelines](CppCoreGuidelines.md)。该文档为 [GH 风格 MarkDown 格式](https://github.github.com/gfm/)。我们有意维持文档简单，（英文原版）基本上是 ASCII，以便于进行诸如语言翻译和格式转换之类的自动化后处理。
+指导方针内容见 [CppCoreGuidelines](CppCoreGuidelines-zh-CN.md)。该文档为 [GH 风格 MarkDown 格式](https://github.github.com/gfm/)。我们有意维持文档简单，（英文原版）基本上是 ASCII，以便于进行诸如语言翻译和格式转换之类的自动化后处理。
 编写者们还维护了[一个适于浏览的版本](http://lynnboy.github.io/CppCoreGuidelines-zh-CN/CppCoreGuidelines)。请注意它由人工集成，因而可能略晚于 master 分支的版本。
 [英文原版](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)。
 


### PR DESCRIPTION
1. 修复github pages部署
2. 修复错误的超链接( `CppCoreGuidelines.md` -> `CppCoreGuidelines-zh-CN.md` )
3. 将部分绝对路径修改为相对路径